### PR TITLE
AnsibleでDBにアプリケーション用ユーザーを作成、冪等性の担保

### DIFF
--- a/ansible/db.yml
+++ b/ansible/db.yml
@@ -2,6 +2,13 @@
   remote_user: bang
   sudo: yes
   vars:
-    mysql_port: 3306
+    root_user:
+      password: bang
+    write_user:
+      name: bang_w
+      password: bang_w
+    read_user:
+      name: bang_r
+      password: bang_r
   roles:
     - db

--- a/ansible/roles/db/files/my.cnf
+++ b/ansible/roles/db/files/my.cnf
@@ -11,7 +11,7 @@ sql_mode=NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES
 skip-name-resolve
 wait_timeout = 600
 
-character-set-server = utf8
+character-set-server = utf8mb4
 
 [client]
 # passwd 'bang'
@@ -19,13 +19,13 @@ character-set-server = utf8
 user=root
 password=$1D8xSupsgnPs
 
-default-character-set = utf8
+default-character-set = utf8mb4
  
 [mysqldump]
-default-character-set = utf8
+default-character-set = utf8mb4
  
 [mysql]
-default-character-set = utf8
+default-character-set = utf8mb4
 
 [mysqld_safe]
 log-error=/var/log/mysqld.log

--- a/ansible/roles/db/files/my.cnf
+++ b/ansible/roles/db/files/my.cnf
@@ -1,0 +1,32 @@
+[mysqld]
+user = mysql
+port = 3306
+
+datadir=/var/lib/mysql
+socket=/var/lib/mysql/mysql.sock
+
+symbolic-links=0
+sql_mode=NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES
+
+skip-name-resolve
+wait_timeout = 600
+
+character-set-server = utf8
+
+[client]
+# passwd 'bang'
+# python -c 'import crypt; print crypt.crypt("bang", "$1$SomeSalt$")'
+user=root
+password=$1D8xSupsgnPs
+
+default-character-set = utf8
+ 
+[mysqldump]
+default-character-set = utf8
+ 
+[mysql]
+default-character-set = utf8
+
+[mysqld_safe]
+log-error=/var/log/mysqld.log
+pid-file=/var/run/mysqld/mysqld.pid

--- a/ansible/roles/db/files/my.cnf
+++ b/ansible/roles/db/files/my.cnf
@@ -12,6 +12,11 @@ skip-name-resolve
 wait_timeout = 600
 
 character-set-server = utf8mb4
+collation-server = utf8mb4_unicode_ci
+
+innodb_file_per_table = 1
+innodb_file_format = Barracuda
+innodb_large_prefix
 
 [client]
 # passwd 'bang'

--- a/ansible/roles/db/tasks/main.yml
+++ b/ansible/roles/db/tasks/main.yml
@@ -31,8 +31,6 @@
     name={{ write_user.name }}
     password={{ write_user.password }}
     priv=*.*:ALL
-    login_user=root
-    login_password={{ root_user.password }}
     state=present
 
 - name: create app read users
@@ -40,8 +38,6 @@
     name={{ read_user.name }}
     password={{ read_user.password }}
     priv=*.*:ALL
-    login_user=root
-    login_password={{ root_user.password }}
     state=present
 
 - name: set my.conf to db server

--- a/ansible/roles/db/tasks/main.yml
+++ b/ansible/roles/db/tasks/main.yml
@@ -1,19 +1,53 @@
 ---
-# mysql
+# mysql install
+- name: check mysql has already installed
+  shell: which mysql
+  register: which_mysql
+  failed_when: which_mysql.rc not in [0, 1]
+
 - name: download mysql 5.6
   shell: yum -y install http://dev.mysql.com/get/mysql-community-release-el6-5.noarch.rpm
-  ignore_errors: True
+  when: which_mysql.rc == 1
 
 - name: install mysql 5.6
   shell: yum -y install mysql-community-server
+  when: which_mysql.rc == 1
+
+- name: install mysql relational packages
+  yum: name={{ item }} state=installed
+  with_items:
+    - MySQL-python
+  when: which_mysql.rc == 1
 
 - name: run mysqld
   service: name=mysqld state=running enabled=yes
 
-- name: create root user Password
-  # passwd 'bang'
-  # python -c 'import crypt; print crypt.crypt("bang", "$1$SomeSalt$")'
-  shell: /usr/bin/mysqladmin -u root password $1D8xSupsgnPs
-
+# mysql setting
 # - name: set up mysql_secure_installation
 #   shell: /usr/bin/mysql_secure_installation
+
+- name: create app write users
+  mysql_user:
+    name={{ write_user.name }}
+    password={{ write_user.password }}
+    priv=*.*:ALL
+    login_user=root
+    login_password={{ root_user.password }}
+    state=present
+
+- name: create app read users
+  mysql_user:
+    name={{ read_user.name }}
+    password={{ read_user.password }}
+    priv=*.*:ALL
+    login_user=root
+    login_password={{ root_user.password }}
+    state=present
+
+- name: set my.conf to db server
+  template: src=./../files/my.cnf dest=/etc/my.cnf owner=root mode=0644
+  register: my_conf
+
+- name: restart mysql
+  service: name=mysqld state=restarted
+  when: my_conf.changed

--- a/ansible/roles/ruby/tasks/main.yml
+++ b/ansible/roles/ruby/tasks/main.yml
@@ -6,55 +6,74 @@
 
 - name: Install libselinux-python
   yum: name={{ item }}
-  with_items: 
+  with_items:
     - epel-release
     - libselinux-python
   when: command_result|success and command_result.stdout != 'Disabled'
 
 - name: install ruby
   yum: name=ruby state=absent
- 
+
+# install rbenv
+- name: check rbenv has already installed.
+  stat: path=~/.rbenv
+  register: rbenv_installed
+  sudo: no
+
 - name: check out rbenv
   git: repo={{ rbenv.repo }} dest=~/.rbenv accept_hostkey=yes
+  when: rbenv_installed.stat.exists == False or rbenv_installed.stat.isdir == False
   sudo: no
 
 - name: check out rbenv
   shell: echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bash_profile
+  when: rbenv_installed.stat.exists == False or rbenv_installed.stat.isdir == False
   sudo: no
 
 - name: check out rbenv
   shell: echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
+  when: rbenv_installed.stat.exists == False or rbenv_installed.stat.isdir == False
+  sudo: no
+
+# install ruby-build
+- name: check rbenv has already installed.
+  stat: path=~/.rbenv/plugins/ruby-build
+  register: rubybuild_installed
   sudo: no
 
 - name: checkout ruby-build as rbenv plugin
   git: repo={{ rubybuild.repo }} dest=~/.rbenv/plugins/ruby-build accept_hostkey=yes
+  when: rubybuild_installed.stat.exists == False or rubybuild_installed.stat.isdir == False
   sudo: no
- 
+
 - name: install ruby-build
   shell: /home/bang/.rbenv/plugins/ruby-build/install.sh
- 
+  when: rubybuild_installed.stat.exists == False or rubybuild_installed.stat.isdir == False
+
+# install ruby
 - name: check whether a specific version of ruby is installed or not
   shell: ~/.rbenv/bin/rbenv versions | grep {{ ruby.version }} | tr '*' ' ' | sed -e 's/\s\+//' | cut -f1 -d' '
   register: rbenv_version
   sudo: no
- 
+
 - name: install ruby with rbenv
   command: ~/.rbenv/bin/rbenv install {{ ruby.version }}
   when: rbenv_version.stdout != "{{ ruby.version }}"
   sudo: no
- 
+
 - name: set ruby version global
   command: ~/.rbenv/bin/rbenv global {{ ruby.version }}
   sudo: no
- 
+
+# install gem and relational packages
 - name: update gems
   command: ~/.rbenv/bin/rbenv exec gem update --system
   sudo: no
- 
+
 - name: install bundler gem
   command: ~/.rbenv/bin/rbenv exec gem install bundler --no-ri --no-rdoc
   sudo: no
- 
+
 - name: rbenv rehash
   command: ~/.rbenv/bin/rbenv rehash
   sudo: no

--- a/ansible/roles/webserver/tasks/main.yml
+++ b/ansible/roles/webserver/tasks/main.yml
@@ -4,6 +4,7 @@
   with_items:
     - nodejs
     - npm
+
 - name: install ImageMagick
   yum: name=ImageMagick state=present
 


### PR DESCRIPTION
@shiruco 
AnsibleでMysqlにアプリケーションユーザーを作成。
rootユーザーのパスワードは以下の中盤に記載あるとおり、
my.cnfで設定しないとmysql_userコマンド使うときにmysqlにログインできなくて失敗するので
my.cnfで設定しています。
http://www.kyoshida.jp/ansibledoc-ja/mysql_user_module.html
課題はDBのアプリ用ユーザーのパスワードが平文で直書きされていることです。

また冪等性を担保したので何回もansible-playbook叩けるようにしました。
ただrubyのgem install周りは対応していません。
ansibleのgemコマンドをつかえばいけると思いますmm
以下参考になるかと。
http://qiita.com/itiut@github/items/3e1aaa4f2b5d95efb319